### PR TITLE
Use r strings to avoid SyntaxWarning in python 3.12

### DIFF
--- a/chkcrontab_lib.py
+++ b/chkcrontab_lib.py
@@ -822,12 +822,12 @@ class CronLineFactory(object):
     Returns:
       A CronLine* class (must have a ValidateAndLog method).
     """
-    chkcrontab_cmd = re.compile('##*\s*chkcrontab:\s*(.*)=(.*)')
-    assignment_line_re = re.compile('[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
-    at_line_re = re.compile('@(\S+)\s+(\S+)\s+(.*)')
-    cron_time_field_re = '[\*0-9a-zA-Z,/-]+'
+    chkcrontab_cmd = re.compile(r'##*\s*chkcrontab:\s*(.*)=(.*)')
+    assignment_line_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
+    at_line_re = re.compile(r'@(\S+)\s+(\S+)\s+(.*)')
+    cron_time_field_re = r'[\*0-9a-zA-Z,/-]+'
     time_field_job_line_re = re.compile(
-        '^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
+        r'^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
         (cron_time_field_re, cron_time_field_re, cron_time_field_re,
          cron_time_field_re, cron_time_field_re))
 


### PR DESCRIPTION
With Python 3.12, there's a new warning when using escape sequences that python does not interpret in strings. This will be a SyntaxError in a future version of Python. The reason is these escape sequences are part of the regular expression, and not meant for the python parser. See also: https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes

The way to avoid this is to use r or raw strings.

Note for testing: This warning only shows up when running the python preprocessor. I.e. if you already have a __pycache__ dir with .pyc files, it won't be visible.

```
/tmp/h/chkcrontab/chkcrontab_lib.py:825: SyntaxWarning: invalid escape sequence '\s'
  chkcrontab_cmd = re.compile('##*\s*chkcrontab:\s*(.*)=(.*)')
/tmp/h/chkcrontab/chkcrontab_lib.py:826: SyntaxWarning: invalid escape sequence '\s'
  assignment_line_re = re.compile('[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
/tmp/h/chkcrontab/chkcrontab_lib.py:827: SyntaxWarning: invalid escape sequence '\S'
  at_line_re = re.compile('@(\S+)\s+(\S+)\s+(.*)')
/tmp/h/chkcrontab/chkcrontab_lib.py:828: SyntaxWarning: invalid escape sequence '\*'
  cron_time_field_re = '[\*0-9a-zA-Z,/-]+'
/tmp/h/chkcrontab/chkcrontab_lib.py:830: SyntaxWarning: invalid escape sequence '\s'
  '^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
```
