### PR TITLE
Fix user crontab regular expression

### DIFF
--- a/chkcrontab_lib.py
+++ b/chkcrontab_lib.py
@@ -826,10 +826,16 @@ class CronLineFactory(object):
     assignment_line_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
     at_line_re = re.compile(r'@(\S+)\s+(\S+)\s+(.*)')
     cron_time_field_re = r'[\*0-9a-zA-Z,/-]+'
-    time_field_job_line_re = re.compile(
-        r'^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
-        (cron_time_field_re, cron_time_field_re, cron_time_field_re,
-         cron_time_field_re, cron_time_field_re))
+    if self.is_user_crontab:
+        time_field_job_line_re = re.compile(
+            r'^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(.*)' %
+            (cron_time_field_re, cron_time_field_re, cron_time_field_re,
+             cron_time_field_re, cron_time_field_re))
+    else:
+        time_field_job_line_re = re.compile(
+            r'^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
+            (cron_time_field_re, cron_time_field_re, cron_time_field_re,
+             cron_time_field_re, cron_time_field_re))
 
     if not line:
       return CronLineEmpty()
@@ -861,7 +867,7 @@ class CronLineFactory(object):
           'day of week': match.groups()[4],
           }
       if self.is_user_crontab:
-          return CronLineTime(field, False, match.groups()[5] + " " + match.groups()[6], options)
+          return CronLineTime(field, False, match.groups()[5], options)
       else:
           return CronLineTime(field, match.groups()[5], match.groups()[6], options)
 


### PR DESCRIPTION
The existing code causes a LINE_ERROR for cronjobs that consist of a single command without any parameters. This is due to the fact that the regular expression expects a username string and a command after that, and the conditional is_user_crontab code concats these two strings.

Instead of doing that, this commit introduces a separate regular expression for user crontab lines.